### PR TITLE
Fix DockerContainer#add_exposed_ports.

### DIFF
--- a/core/lib/testcontainers/docker_container.rb
+++ b/core/lib/testcontainers/docker_container.rb
@@ -80,8 +80,8 @@ module Testcontainers
       port = normalize_port(port)
       @exposed_ports ||= {}
       @port_bindings ||= {}
-      @exposed_ports[port] = {}
-      @port_bindings[port] = [{"HostPort" => ""}]
+      @exposed_ports[port] ||= {}
+      @port_bindings[port] ||= [{"HostPort" => ""}]
       @exposed_ports
     end
 

--- a/core/test/docker_container_test.rb
+++ b/core/test/docker_container_test.rb
@@ -123,6 +123,18 @@ class DockerContainerTest < TestcontainersTest
     assert_equal({"80/tcp" => [{"HostPort" => "8080"}], "443/tcp" => [{"HostPort" => "8081"}]}, container.port_bindings)
   end
 
+  def test_it_adds_exposed_ports_without_overwriting_fixed_exposed_ports
+    container = Testcontainers::DockerContainer.new("hello-world")
+    container.add_fixed_exposed_port(80, 8080)
+
+    assert_equal({"80/tcp" => {}}, container.exposed_ports)
+    assert_equal({"80/tcp" => [{"HostPort" => "8080"}]}, container.port_bindings)
+
+    container.add_exposed_ports(80)
+    assert_equal({"80/tcp" => {}}, container.exposed_ports)
+    assert_equal({"80/tcp" => [{"HostPort" => "8080"}]}, container.port_bindings)
+  end
+
   def test_it_adds_a_volume
     container = Testcontainers::DockerContainer.new("hello-world")
 


### PR DESCRIPTION
Avoid overriding the PortBinding settings set by add_fixed_exposed_port
when the same port is exposed with add_exposed_ports in a later stage.

This allows to the modules to call to a default add_exposed_ports on
start without overriding the previous port bindings set by the user on
purpose.
