### PR TITLE
Remove support for custom port and password in Redis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ PATH
 PATH
   remote: redis
   specs:
-    testcontainers-redis (0.1.0)
+    testcontainers-redis (0.1.1)
       testcontainers-core (~> 0.1.2)
 
 GEM

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- Remove support for custom password and port, those aren't supported by
+  Redis images
+
 ## [0.1.0] - 2023-05-13
 
 ### Added

--- a/redis/Gemfile.lock
+++ b/redis/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-redis (0.1.0)
+    testcontainers-redis (0.1.1)
       testcontainers-core (~> 0.1.2)
 
 GEM

--- a/redis/lib/testcontainers/redis.rb
+++ b/redis/lib/testcontainers/redis.rb
@@ -13,18 +13,14 @@ module Testcontainers
     # Default image used by the container
     REDIS_DEFAULT_IMAGE = "redis:latest"
 
-    attr_reader :port, :password
-
     # Initializes a new instance of RedisContainer
     #
     # @param image [String] the image to use
     # @param port [String] the port to use
     # @param kwargs [Hash] the options to pass to the container. See {DockerContainer#initialize}
     # @return [RedisContainer] a new instance of RedisContainer
-    def initialize(image = REDIS_DEFAULT_IMAGE, port: nil, **kwargs)
+    def initialize(image = REDIS_DEFAULT_IMAGE, **kwargs)
       super(image, **kwargs)
-      @port = port || ENV.fetch("REDIS_PORT", REDIS_DEFAULT_PORT)
-      @password = password || ENV.fetch("REDIS_PASSWORD", nil)
       @wait_for ||= add_wait_for(:logs, /Ready to accept connections/)
     end
 
@@ -32,18 +28,14 @@ module Testcontainers
     #
     # @return [RedisContainer] self
     def start
-      with_exposed_ports(@port)
-      _configure
+      with_exposed_ports(port)
       super
     end
 
-    # Sets the password to use
-    #
-    # @param password [String] the password to use
-    # @return [RedisContainer] self
-    def with_password(password)
-      @password = password
-      self
+    # Returns the port used by the container
+    # @return [Integer] the port used by the container
+    def port
+      REDIS_DEFAULT_PORT
     end
 
     # Returns the Redis connection url (e.g. redis://:password@localhost:6379/0)
@@ -61,11 +53,5 @@ module Testcontainers
     end
 
     alias_method :database_url, :redis_url
-
-    private
-
-    def _configure
-      add_env("REDIS_PASSWORD", @password) unless @password.nil? || @password.empty?
-    end
   end
 end

--- a/redis/lib/testcontainers/redis/version.rb
+++ b/redis/lib/testcontainers/redis/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Redis
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/redis/test/redis_container_test.rb
+++ b/redis/test/redis_container_test.rb
@@ -39,11 +39,6 @@ class RedisContainerTest < TestcontainersTest
     assert @container.mapped_port(6379)
   end
 
-  def test_it_supports_custom_port
-    container = Testcontainers::RedisContainer.new(port: 16379)
-    assert_equal 16379, container.port
-  end
-
   def test_it_supports_custom_keyword_arguments
     container = Testcontainers::RedisContainer.new(filesystem_binds: ["#{Dir.pwd}/custom/conf:/usr/local/etc/redis/redis.conf:rw"])
     assert_equal ["#{Dir.pwd}/custom/conf:/usr/local/etc/redis/redis.conf:rw"], container.filesystem_binds


### PR DESCRIPTION
Custom port and password aren't supported by the Redis image
